### PR TITLE
reset_classifier: fix it to actually work, expose toggle param for gpu

### DIFF
--- a/models/cswin.py
+++ b/models/cswin.py
@@ -326,15 +326,22 @@ class CSWinTransformer(nn.Module):
     def get_classifier(self):
         return self.head
     
-    def reset_classifier(self, num_classes, global_pool=''):
-        if self.num_classes != num_classes:
-            print ('reset head to', num_classes)
+    def reset_classifier(self, num_classes, force=False, to_gpu=False):
+        if self.num_classes != num_classes or force:
+            print("reset head to", num_classes)
             self.num_classes = num_classes
-            self.head = nn.Linear(self.out_dim, num_classes) if num_classes > 0 else nn.Identity()
-            self.head = self.head.cuda()
-            trunc_normal_(self.head.weight, std=.02)
+            self.head = (
+                nn.Linear(self.head.in_features, num_classes)
+                if num_classes > 0
+                else nn.Identity()
+            )
+            if to_gpu:
+                self.head = self.head.cuda()
+            # init new head   
+            trunc_normal_(self.head.weight, std=0.02)
             if self.head.bias is not None:
                 nn.init.constant_(self.head.bias, 0)
+
 
     def forward_features(self, x):
         B = x.shape[0]


### PR DESCRIPTION
Currently the reset_classifier function does not work, as there is no self.out_dim in the model.

I've updated reset_classifier to work by using the current head in_features to determine the in channels for the new head.

I also removed global_pool param, which was dead weight and was not being used.
I added a force option in case you are not changing num_classes but still want to reset (defaults to off).
Finally, added a to_gpu flag b/c in building a model that is on cpu atm, you don't want to force only the head to gpu if the entire model will be moved later, which was how the initial version was setup.  
