### PR TITLE
fix: use correct args for loading eval_checkpoint

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -689,7 +689,7 @@ def main():
     best_epoch = None
     
     if args.eval_checkpoint:  # evaluate the model
-        load_checkpoint(model, args.eval_checkpoint, args.model_ema)
+        load_checkpoint(args, model, args.eval_checkpoint, args.model_ema)
         val_metrics = validate(model, loader_eval, validate_loss_fn, args)
         print(f"Top-1 accuracy of the model is: {val_metrics['top1']:.1f}%")
         return


### PR DESCRIPTION
When `--eval_checkpoint` is supplied, incorrect arguments were supplied to `load_checkpoint`. That is fixed here.